### PR TITLE
LRDOCS-7079 document `ConfigurationFieldOptionsProvider` interface

### DIFF
--- a/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
+++ b/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
@@ -53,6 +53,9 @@ This automatically scopes your configuration to `SYSTEM`.
     your application to work properly. Use the `deflt` property to specify
     a default value.
 
+    | **Note:** You can dynamically populate select field options with the 
+    | [`ConfigurationFieldsOptionProvider` interface](/docs/7-2/frameworks/-/knowledge_base/f/dynamically-populating-select-list-fields-in-the-configuration-ui)
+
     The fully-qualified name of the `Meta` class above is
     `aQute.bnd.annotation.metatype.Meta`. For more information about this class and
     the `Meta.OCD` and `Meta.AD` annotations, please refer to the 

--- a/developer/frameworks/articles/configuration/11-dynamically-populating-select-fields.markdown
+++ b/developer/frameworks/articles/configuration/11-dynamically-populating-select-fields.markdown
@@ -1,0 +1,93 @@
+---
+header-id: dynamically-populating-select-list-fields-in-the-configuration-ui
+---
+
+# Dynamically Populating Select List Fields in the Configuration UI
+
+[TOC levels=1-4]
+
+Previously you had to hardcode config options in the [Configuration interface](/docs/7-2/frameworks/-/knowledge_base/f/creating-a-configuration-interface) 
+if you wanted to populate select list fields. This is no longer the case, thanks 
+to the [`ConfigurationFieldOptionsProvider` interface](@app-ref@/configuration-admin/latest/javadocs/com/liferay/configuration/admin/definition/ConfigurationFieldOptionsProvider.html). 
+Rather than hardcode these values, the `ConfigurationFieldOptionsProvider` 
+interface defines these values at runtime. 
+
+Follow these steps to dynamically populate the select list fields in your 
+configuration UI:
+
+1.  Create a class and add an `@Component` annotation that registers the 
+    `ConfigurationFieldOptionsProvider.class` service and includes the two 
+    properties shown below:
+
+    - `configuration.field.name`: The name of the attribute in the configuration 
+      interface
+
+    - `configuration.pid`: The ID of the corresponding configuration interface 
+      (usually the fully qualified class name)
+
+    An example configuration is shown below:
+
+    ```java
+    @Component(
+    	property = {
+    		"configuration.field.name=enabledClassNames",
+    		"configuration.pid=com.liferay.asset.auto.tagger.google.cloud.natural.language.internal.configuration.GCloudNaturalLanguageAssetAutoTaggerCompanyConfiguration",
+    		"configuration.pid=com.liferay.asset.auto.tagger.opennlp.internal.configuration.OpenNLPDocumentAssetAutoTaggerCompanyConfiguration"
+    	},
+    	service = ConfigurationFieldOptionsProvider.class
+    )
+    ```
+
+2.  Create a class that implements the `ConfigurationFieldOptionsProvider` 
+    interface:
+
+    ```java    
+    public class MyConfigurationFieldOptionsProvider implements 
+    ConfigurationFieldOptionsProvider {
+        ..
+    }
+    ```
+
+3.  Use the `getOptions()` method to retrieve the options from the Configuration 
+    interface and populate the configuration fields with their labels and 
+    values, as shown in the example below:
+
+    ```java    
+    public List<Option> getOptions() {
+    	List<AssetRendererFactory<?>> assetRendererFactories =
+    		AssetRendererFactoryRegistryUtil.getAssetRendererFactories(
+    			CompanyThreadLocal.getCompanyId());
+
+    	Stream<AssetRendererFactory<?>> stream =
+    		assetRendererFactories.stream();
+
+    	return stream.filter(
+    		assetRendererFactory -> {
+    			TextExtractor textExtractor =
+    				_textExtractorTracker.getTextExtractor(
+    					assetRendererFactory.getClassName());
+
+    			return textExtractor != null;
+    		}
+    	).map(
+    		assetRendererFactory -> new Option() {
+
+    			@Override
+    			public String getLabel(Locale locale) {
+    				return assetRendererFactory.getTypeName(locale);
+    			}
+
+    			@Override
+    			public String getValue() {
+    				return assetRendererFactory.getClassName();
+    			}
+
+    		}
+    	).collect(
+    		Collectors.toList()
+    	);
+    }
+    ```
+    
+Great! Now you know how to dynamically populate select fields in your 
+configuration's UI. 


### PR DESCRIPTION
@rbohl 

Questions:
What are the requirements for the `getOptions()` method? 
The example uses the TextExtractor (https://github.com/liferay/liferay-portal/blob/912d7fabf61a8603d8ad67c716400ddda33b3cfb/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/admin/definition/EnabledClassNamesConfigurationFieldOptionsProvider.java#L56). Would this vary depending on the asset, or is this required? I just use the example code to demonstrate what's required, but we may want to break it down more. I wasn't sure what is common Java (such as the List and Stream) and what we may need to explain more.

Is this available in a specific FP? 

Do we want to remove examples of the old approach, or simply state that the new approach is also available? For now I just noted that the new approach is available.