### PR TITLE
7.0.x | LRDOCS-5272 Fix LES matrix link in Marvel doc

### DIFF
--- a/discover/deployment/articles-dxp/08-liferay-enterprise-search/04-marvel.markdown
+++ b/discover/deployment/articles-dxp/08-liferay-enterprise-search/04-marvel.markdown
@@ -76,7 +76,7 @@ Elasticsearch for @product@.
         ./bin/plugin install marvel-agent
 
 2.  Download a
-    [compatible](https://web.liferay.com/group/customer/dxp/support/compatibility-matrix/enterprise-search)
+    [compatible](https://help.liferay.com/hc/en-us/articles/360016511651)
     version of [Kibana](https://www.elastic.co/downloads/kibana) and extract it
     to your Liferay Home folder.
 


### PR DESCRIPTION
Hey Russ,

The original broken link reported on https://issues.liferay.com/browse/LRDOCS-5272 is already fixed so I just updated the Marvel doc to use the correct LES matrix link in HC.

Cheers,
Tibor