### PR TITLE
LRDOCS-7605 Fixing Search Queries example & snippets

### DIFF
--- a/en/developer/frameworks/articles/search/03-queries-and-filters/02-building-search-queries-and-filters.markdown
+++ b/en/developer/frameworks/articles/search/03-queries-and-filters/02-building-search-queries-and-filters.markdown
@@ -200,7 +200,26 @@ shown here, with a simple message printed in the log for each one.
 			});
     ```
 
-## Example
+### Search Insights: Request and Response Strings
+
+When building your search application, it can be useful to inspect how the request string (translated into the search engine's dialect) looks like and also, to see the response string from returned by the search server.
+
+You can get these from the `SearchResponse` as
+
+```java
+    searchResponse.getRequestString();
+    searchResponse.getResponseString();
+``` 
+
+The format depends on your search engine: in case of Elasticsearch, it will be a JSON.
+
+        +$$$
+
+        **Note:** The JSON you will get as a request string is pruned from several Elasticsearch query defaults for clarity. If you want to see the full request JSON that Elasticsearch processed you will need to adjust the log levels for your Elasticsearch server.
+
+        $$$
+
+### Queries Example
 
 Here's a mostly-complete example code snippet, which performs a `MatchQuery` on the
 `title_en_US` field for the value `legal`, a `TermsQuery` on the `folderId`
@@ -295,6 +314,11 @@ public class MySearchComponent {
 
 				resultsList.add(uid);
 			});
+
+		System.out.println(
+			"Request String:\n" + searchResponse.getRequestString());
+		System.out.println(
+			"Response String:\n" + searchResponse.getResponseString());
 
 		return resultsList;
 	}

--- a/en/developer/frameworks/articles/search/03-queries-and-filters/02-building-search-queries-and-filters.markdown
+++ b/en/developer/frameworks/articles/search/03-queries-and-filters/02-building-search-queries-and-filters.markdown
@@ -16,6 +16,20 @@ all queries and filters.
 A mostly-complete code snippet for building Queries is provided for your
 copying and pasting convenience [below](#example).
 
+### Declare Gradle Dependencies
+
+Add the following to your `build.gradle` file:
+
+```gradle
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
+	compileOnly group: "com.liferay.portal", name: "release.portal.api", version: "7.2.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+}
+```
+
+With this, you will be able to import the Query and Filter types and other necessary Search APIs shipped with @product@.
+
 ### Reference the Search Services
 
 To satisfy the dependencies of the example code presented here, get references to


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7605

Hey Russ,

Sending on top of you changes, against your branch so it's easier to see the diff here.

Regarding the "Filters" section, it has to be updated: while it is true that you don't have Query and Filter at API level in Elasticsearch, you can add query clauses as "Filter Context", something we also use in the product.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#query-context

For example, if you extend the example with 
```java
		TermQuery groupIdFilterQuery = queries.term(Field.GROUP_ID, groupId);

		booleanQuery.addFilterQueryClauses(groupIdFilterQuery);
```

and you pass in an actual `groupId`, you will limit the document set to the given site (documents with that `groupId`) and your query will look like this:
```json
{
  "from": 0,
  "size": 10000,
  "query": {
    "bool": {
      "must": [
        {
          "bool": {
            "must": [
              {
                "terms": {
                  "folderId": [
                    "0"
                  ]
                }
              },
              {
                "match": {
                  "title_en_US": {
                    "query": "liferay"
                  }
                }
              }
            ],
            "filter": [
              {
                "term": {
                  "groupId": {
                    "value": 20124
                  }
                }
              }
            ]
          }
        },
       {...}}}}
```

Notice the new "filter" context in the JSON.

Another point: the above code will produce a query with a bunch of other fields, added by the indexers and contributors, because it's not limited to only certain models and it is not a low-level search either.

This means that while the MUST clauses we add play an important role in the matches you get, but depending on your env and the sample content you created, there can be additional matches in other fields like `description_xx_YY` etc.

Regards,
Tibor